### PR TITLE
Fix google widget timing issue

### DIFF
--- a/core/java/android/widget/QuickContactBadge.java
+++ b/core/java/android/widget/QuickContactBadge.java
@@ -396,8 +396,9 @@ public class QuickContactBadge extends ImageView implements OnClickListener {
                 // Prompt user to add this person to contacts
                 final Intent intent = new Intent(Intents.SHOW_OR_CREATE_CONTACT, createUri);
                 if (extras != null) {
-                    extras.remove(EXTRA_URI_CONTENT);
-                    intent.putExtras(extras);
+                    Bundle bundle = new Bundle(extras);
+                    bundle.remove(EXTRA_URI_CONTENT);
+                    intent.putExtras(bundle);
                 }
                 getContext().startActivity(intent);
             }


### PR DESCRIPTION
If the user of QuickContactBadge widget do not assign extras,
widget will create one, wrappter URI data in it and use this extra for
all requests,if multiple click events happened in short time it may
cause a bug as the first query finished and URI data will be removed
from extras, but the next query already sent, so when the second query
complete, there is no URI in extra and result in null pointer exception.

Don't remove the URI from extra directly,but copy the extra to
another one and send it out after remove the URI, so the URI null
pointer exception wouldn't happened anymore.

Change-Id: I4ef56d29883f79f115e4b9523ced0abfd0978fd7
Bug: 195089668
Signed-off-by: Pranav Vashi <neobuddy89@gmail.com>