### PR TITLE
SystemUI: Allow limiting AOD & ambient display refresh rate

### DIFF
--- a/packages/SystemUI/res/values/flamingo_config.xml
+++ b/packages/SystemUI/res/values/flamingo_config.xml
@@ -30,5 +30,8 @@
 
     <!-- Color of the UDFPS pressed view -->
     <color name="config_udfpsColor">#ffffffff</color>
+    
+    <!-- Preferred max refresh rate at AOD & Ambient Display, if supported by the display. -->
+    <integer name="config_aodMaxRefreshRate">-1</integer>
 
 </resources>


### PR DESCRIPTION
via overlay. This should save some juice while showing it. AOSP has implementation for keyguard & AOD but lack AOD only - We still want to show keyguard at max rate to allow better UX

This feature should behave fine with config_keyguardMaxRefreshRate and/or config_keyguardPrefferedRefreshRate set and thus allows setting a different rate for each

Suggested-by: John Galt <johngaltfirstrun@gmail.com>