### PR TITLE
SystemUI: Use max Display.Mode in AuthController as well

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/biometrics/AuthController.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/AuthController.java
@@ -54,8 +54,10 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.RemoteException;
 import android.os.UserManager;
+import android.util.DisplayUtils;
 import android.util.Log;
 import android.util.SparseBooleanArray;
+import android.view.Display;
 import android.view.DisplayInfo;
 import android.view.MotionEvent;
 import android.view.WindowManager;
@@ -111,8 +113,6 @@ public class AuthController extends CoreStartable implements CommandQueue.Callba
     @Nullable private final FaceManager mFaceManager;
     private final Provider<UdfpsController> mUdfpsControllerFactory;
     private final Provider<SidefpsController> mSidefpsControllerFactory;
-
-    @NonNull private Point mStableDisplaySize = new Point();
 
     @Nullable private final PointF mFaceAuthSensorLocation;
     @Nullable private PointF mFingerprintLocation;
@@ -486,9 +486,11 @@ public class AuthController extends CoreStartable implements CommandQueue.Callba
         }
         DisplayInfo displayInfo = new DisplayInfo();
         mContext.getDisplay().getDisplayInfo(displayInfo);
-        final float scaleFactor = android.util.DisplayUtils.getPhysicalPixelDisplaySizeRatio(
-                mStableDisplaySize.x, mStableDisplaySize.y, displayInfo.getNaturalWidth(),
-                displayInfo.getNaturalHeight());
+        final Display.Mode maxDisplayMode =
+                DisplayUtils.getMaximumResolutionDisplayMode(displayInfo.supportedModes);
+        final float scaleFactor = DisplayUtils.getPhysicalPixelDisplaySizeRatio(
+                maxDisplayMode.getPhysicalWidth(), maxDisplayMode.getPhysicalHeight(),
+                displayInfo.getNaturalWidth(), displayInfo.getNaturalHeight());
         return new PointF(mFaceAuthSensorLocation.x * scaleFactor,
                 mFaceAuthSensorLocation.y * scaleFactor);
     }
@@ -636,9 +638,11 @@ public class AuthController extends CoreStartable implements CommandQueue.Callba
         if (mUdfpsController != null) {
             final DisplayInfo displayInfo = new DisplayInfo();
             mContext.getDisplay().getDisplayInfo(displayInfo);
-            final float scaleFactor = android.util.DisplayUtils.getPhysicalPixelDisplaySizeRatio(
-                    mStableDisplaySize.x, mStableDisplaySize.y, displayInfo.getNaturalWidth(),
-                    displayInfo.getNaturalHeight());
+            final Display.Mode maxDisplayMode =
+                    DisplayUtils.getMaximumResolutionDisplayMode(displayInfo.supportedModes);
+            final float scaleFactor = DisplayUtils.getPhysicalPixelDisplaySizeRatio(
+                    maxDisplayMode.getPhysicalWidth(), maxDisplayMode.getPhysicalHeight(),
+                    displayInfo.getNaturalWidth(), displayInfo.getNaturalHeight());
 
             final FingerprintSensorPropertiesInternal udfpsProp = mUdfpsProps.get(0);
             final Rect previousUdfpsBounds = mUdfpsBounds;
@@ -665,7 +669,6 @@ public class AuthController extends CoreStartable implements CommandQueue.Callba
                     mFingerprintAuthenticatorsRegisteredCallback);
         }
 
-        mStableDisplaySize = mDisplayManager.getStableDisplaySize();
         mActivityTaskManager.registerTaskStackListener(mTaskStackListener);
     }
 


### PR DESCRIPTION
This was missed in 0f7cc0128b9cf341eb3e0e657d4e6a416440ee53.

Test: On device with UDFPS and multiple resolutions, switch resolution
      and observe that UDFPS icon is still in correct location.
Change-Id: Ib6c4625a17032c913e4efc57dd41d16d3a3a25ee